### PR TITLE
Fix for python3.

### DIFF
--- a/cmake/rosparam_handler-macros.cmake
+++ b/cmake/rosparam_handler-macros.cmake
@@ -39,6 +39,7 @@ macro(generate_ros_parameter_files)
             assert(CATKIN_ENV)
             set(_cmd
                     ${CATKIN_ENV}
+                    ${PYTHON_EXECUTABLE}
                     ${_input}
                     ${ROSPARAM_HANDLER_ROOT_DIR}
                     ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_SHARE_DESTINATION}

--- a/templates/Parameters.py.template
+++ b/templates/Parameters.py.template
@@ -28,7 +28,7 @@ class ${ClassName}Parameters(dict):
         Reads and initializes parameters with values from parameter server.
         Called automatically at initialization.
         """
-        for k, v in self.iteritems():
+        for k, v in iter(self.items()):
             config = next((item for item in param_description if item["name"] == k), None)
             if config['constant']:
                 self.test_const_param(k)
@@ -41,7 +41,7 @@ class ${ClassName}Parameters(dict):
         """
         Sets parameters with current values on the parameter server.
         """
-        for param_name, param_value in self.iteritems():
+        for param_name, param_value in iter(self.items()):
             config = next((item for item in param_description if item["name"] == param_name), None)
             if not config['constant']:
                 full_name = "/" + param_name if config['global_scope'] else "~" + param_name
@@ -53,7 +53,7 @@ class ${ClassName}Parameters(dict):
         Should be called in the callback of dynamic_reconfigure.
         :param config: config object from dynamic reconfigure
         """
-        for k, v in config.iteritems():
+        for k, v in iter(config.items()):
             # handle reserved name groups
             if k == "groups":
                 continue

--- a/test/cfg/Defaults.params
+++ b/test/cfg/Defaults.params
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 ####### workaround so that the module is found #######
 import sys
 import os

--- a/test/cfg/DefaultsAtLaunch.params
+++ b/test/cfg/DefaultsAtLaunch.params
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 ####### workaround so that the module is found #######
 import sys
 import os

--- a/test/cfg/DefaultsMissing.params
+++ b/test/cfg/DefaultsMissing.params
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 ####### workaround so that the module is found for test files #######
 import sys
 import os

--- a/test/cfg/MinMax.params
+++ b/test/cfg/MinMax.params
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 ####### workaround so that the module is found #######
 import sys
 import os


### PR DESCRIPTION
I was getting the following error when trying to construct a Parameters object in python:
```
 ... Parameters.py", line 31, in from_param_server
    for k, v in self.iteritems():
KeyError: 'iteritems'
```
I applied the following migration in the python template code to resolve the issue: https://www.python.org/dev/peps/pep-0469/#id2